### PR TITLE
Uploading rework Def files

### DIFF
--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0021.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0021.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0021
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,43 +10,43 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# IO configuration chain was successful
 gpio_l = [
 ['IO[0]', H_NONE],
-['IO[1]', H_DEPENDENT],
-['IO[2]', H_DEPENDENT],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_INDEPENDENT],
 ['IO[3]', H_DEPENDENT],
 ['IO[4]', H_DEPENDENT],
 ['IO[5]', H_INDEPENDENT],
 ['IO[6]', H_INDEPENDENT],
 ['IO[7]', H_INDEPENDENT],
-['IO[8]', H_UNKNOWN],
-['IO[9]', H_UNKNOWN],
-['IO[10]', H_UNKNOWN],
-['IO[11]', H_UNKNOWN],
-['IO[12]', H_UNKNOWN],
-['IO[13]', H_UNKNOWN],
-['IO[14]', H_UNKNOWN],
-['IO[15]', H_UNKNOWN],
-['IO[16]', H_UNKNOWN],
-['IO[17]', H_UNKNOWN],
-['IO[18]', H_UNKNOWN],
+['IO[8]', H_INDEPENDENT],
+['IO[9]', H_INDEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_INDEPENDENT],
+['IO[12]', H_DEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# configuration failed in gpio[28], anything before is invalid
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
-['IO[35]', H_DEPENDENT],
-['IO[34]', H_DEPENDENT],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
 ['IO[33]', H_INDEPENDENT],
 ['IO[32]', H_INDEPENDENT],
 ['IO[31]', H_INDEPENDENT],
 ['IO[30]', H_INDEPENDENT],
 ['IO[29]', H_INDEPENDENT],
-['IO[28]', H_DEPENDENT],
-['IO[27]', H_INDEPENDENT],
-['IO[26]', H_INDEPENDENT],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
 ['IO[25]', H_UNKNOWN],
 ['IO[24]', H_UNKNOWN],
 ['IO[23]', H_UNKNOWN],

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0033.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0033.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0033
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,16 +10,16 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# configuration failed in gpio[2], anything after is invalid
 gpio_l = [
 ['IO[0]', H_NONE],
-['IO[1]', H_DEPENDENT],
-['IO[2]', H_DEPENDENT],
-['IO[3]', H_DEPENDENT],
-['IO[4]', H_DEPENDENT],
-['IO[5]', H_INDEPENDENT],
-['IO[6]', H_INDEPENDENT],
-['IO[7]', H_INDEPENDENT],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_UNKNOWN],
+['IO[3]', H_UNKNOWN],
+['IO[4]', H_UNKNOWN],
+['IO[5]', H_UNKNOWN],
+['IO[6]', H_UNKNOWN],
+['IO[7]', H_UNKNOWN],
 ['IO[8]', H_UNKNOWN],
 ['IO[9]', H_UNKNOWN],
 ['IO[10]', H_UNKNOWN],
@@ -33,25 +33,25 @@ gpio_l = [
 ['IO[18]', H_UNKNOWN],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# configuration failed in gpio[19], anything before is invalid
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
+['IO[36]', H_INDEPENDENT],
 ['IO[35]', H_DEPENDENT],
-['IO[34]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
 ['IO[33]', H_INDEPENDENT],
 ['IO[32]', H_INDEPENDENT],
 ['IO[31]', H_INDEPENDENT],
-['IO[30]', H_INDEPENDENT],
-['IO[29]', H_INDEPENDENT],
+['IO[30]', H_DEPENDENT],
+['IO[29]', H_DEPENDENT],
 ['IO[28]', H_DEPENDENT],
 ['IO[27]', H_INDEPENDENT],
-['IO[26]', H_INDEPENDENT],
-['IO[25]', H_UNKNOWN],
-['IO[24]', H_UNKNOWN],
-['IO[23]', H_UNKNOWN],
-['IO[22]', H_UNKNOWN],
-['IO[21]', H_UNKNOWN],
-['IO[20]', H_UNKNOWN],
+['IO[26]', H_DEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
 ['IO[19]', H_UNKNOWN],
 ]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0049.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0049.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0049
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,16 +10,16 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# configuration failed in gpio[6], anything after is invalid
 gpio_l = [
 ['IO[0]', H_NONE],
-['IO[1]', H_DEPENDENT],
+['IO[1]', H_INDEPENDENT],
 ['IO[2]', H_DEPENDENT],
-['IO[3]', H_DEPENDENT],
+['IO[3]', H_INDEPENDENT],
 ['IO[4]', H_DEPENDENT],
 ['IO[5]', H_INDEPENDENT],
-['IO[6]', H_INDEPENDENT],
-['IO[7]', H_INDEPENDENT],
+['IO[6]', H_UNKNOWN],
+['IO[7]', H_UNKNOWN],
 ['IO[8]', H_UNKNOWN],
 ['IO[9]', H_UNKNOWN],
 ['IO[10]', H_UNKNOWN],
@@ -33,25 +33,25 @@ gpio_l = [
 ['IO[18]', H_UNKNOWN],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# IO configuration chain was successful
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
+['IO[36]', H_INDEPENDENT],
 ['IO[35]', H_DEPENDENT],
-['IO[34]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
 ['IO[33]', H_INDEPENDENT],
 ['IO[32]', H_INDEPENDENT],
 ['IO[31]', H_INDEPENDENT],
-['IO[30]', H_INDEPENDENT],
+['IO[30]', H_DEPENDENT],
 ['IO[29]', H_INDEPENDENT],
-['IO[28]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
 ['IO[27]', H_INDEPENDENT],
 ['IO[26]', H_INDEPENDENT],
-['IO[25]', H_UNKNOWN],
-['IO[24]', H_UNKNOWN],
-['IO[23]', H_UNKNOWN],
-['IO[22]', H_UNKNOWN],
-['IO[21]', H_UNKNOWN],
-['IO[20]', H_UNKNOWN],
-['IO[19]', H_UNKNOWN],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_DEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
 ]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0124.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0124.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0124
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,16 +10,16 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# configuration failed in gpio[4], anything after is invalid
 gpio_l = [
 ['IO[0]', H_NONE],
-['IO[1]', H_DEPENDENT],
+['IO[1]', H_INDEPENDENT],
 ['IO[2]', H_DEPENDENT],
-['IO[3]', H_DEPENDENT],
-['IO[4]', H_DEPENDENT],
-['IO[5]', H_INDEPENDENT],
-['IO[6]', H_INDEPENDENT],
-['IO[7]', H_INDEPENDENT],
+['IO[3]', H_INDEPENDENT],
+['IO[4]', H_UNKNOWN],
+['IO[5]', H_UNKNOWN],
+['IO[6]', H_UNKNOWN],
+['IO[7]', H_UNKNOWN],
 ['IO[8]', H_UNKNOWN],
 ['IO[9]', H_UNKNOWN],
 ['IO[10]', H_UNKNOWN],
@@ -33,25 +33,25 @@ gpio_l = [
 ['IO[18]', H_UNKNOWN],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# IO configuration chain was successful
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
-['IO[35]', H_DEPENDENT],
-['IO[34]', H_DEPENDENT],
-['IO[33]', H_INDEPENDENT],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_DEPENDENT],
 ['IO[32]', H_INDEPENDENT],
 ['IO[31]', H_INDEPENDENT],
 ['IO[30]', H_INDEPENDENT],
 ['IO[29]', H_INDEPENDENT],
-['IO[28]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
 ['IO[27]', H_INDEPENDENT],
-['IO[26]', H_INDEPENDENT],
-['IO[25]', H_UNKNOWN],
-['IO[24]', H_UNKNOWN],
-['IO[23]', H_UNKNOWN],
-['IO[22]', H_UNKNOWN],
-['IO[21]', H_UNKNOWN],
-['IO[20]', H_UNKNOWN],
-['IO[19]', H_UNKNOWN],
+['IO[26]', H_DEPENDENT],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
 ]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0128.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0128.py
@@ -1,0 +1,57 @@
+# gpio_config_def.py file for part VSD0128
+# io_config -- version 1.2.1
+voltage = 1.60
+analog = False
+
+H_NONE        = 0  
+H_DEPENDENT   = 1  
+H_INDEPENDENT = 2  
+H_SPECIAL     = 3  
+H_UNKNOWN     = 4  
+
+# voltage: 1.6
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_INDEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_DEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_INDEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_DEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_INDEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.6
+# configuration failed in gpio[31], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_DEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0242.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0242.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0242
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,16 +10,16 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# configuration failed in gpio[6], anything after is invalid
 gpio_l = [
 ['IO[0]', H_NONE],
 ['IO[1]', H_DEPENDENT],
 ['IO[2]', H_DEPENDENT],
-['IO[3]', H_DEPENDENT],
+['IO[3]', H_INDEPENDENT],
 ['IO[4]', H_DEPENDENT],
 ['IO[5]', H_INDEPENDENT],
-['IO[6]', H_INDEPENDENT],
-['IO[7]', H_INDEPENDENT],
+['IO[6]', H_UNKNOWN],
+['IO[7]', H_UNKNOWN],
 ['IO[8]', H_UNKNOWN],
 ['IO[9]', H_UNKNOWN],
 ['IO[10]', H_UNKNOWN],
@@ -33,25 +33,25 @@ gpio_l = [
 ['IO[18]', H_UNKNOWN],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# IO configuration chain was successful
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
-['IO[35]', H_DEPENDENT],
-['IO[34]', H_DEPENDENT],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
 ['IO[33]', H_INDEPENDENT],
-['IO[32]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
 ['IO[31]', H_INDEPENDENT],
 ['IO[30]', H_INDEPENDENT],
 ['IO[29]', H_INDEPENDENT],
-['IO[28]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
 ['IO[27]', H_INDEPENDENT],
 ['IO[26]', H_INDEPENDENT],
-['IO[25]', H_UNKNOWN],
-['IO[24]', H_UNKNOWN],
-['IO[23]', H_UNKNOWN],
-['IO[22]', H_UNKNOWN],
-['IO[21]', H_UNKNOWN],
-['IO[20]', H_UNKNOWN],
-['IO[19]', H_UNKNOWN],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_DEPENDENT],
+['IO[19]', H_INDEPENDENT],
 ]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0245.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0245.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0245
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,17 +10,17 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# configuration failed in gpio[9], anything after is invalid
 gpio_l = [
 ['IO[0]', H_NONE],
-['IO[1]', H_DEPENDENT],
+['IO[1]', H_INDEPENDENT],
 ['IO[2]', H_DEPENDENT],
 ['IO[3]', H_DEPENDENT],
 ['IO[4]', H_DEPENDENT],
-['IO[5]', H_INDEPENDENT],
+['IO[5]', H_DEPENDENT],
 ['IO[6]', H_INDEPENDENT],
 ['IO[7]', H_INDEPENDENT],
-['IO[8]', H_UNKNOWN],
+['IO[8]', H_INDEPENDENT],
 ['IO[9]', H_UNKNOWN],
 ['IO[10]', H_UNKNOWN],
 ['IO[11]', H_UNKNOWN],
@@ -33,20 +33,20 @@ gpio_l = [
 ['IO[18]', H_UNKNOWN],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# configuration failed in gpio[27], anything before is invalid
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
-['IO[35]', H_DEPENDENT],
-['IO[34]', H_DEPENDENT],
-['IO[33]', H_INDEPENDENT],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_DEPENDENT],
 ['IO[32]', H_INDEPENDENT],
 ['IO[31]', H_INDEPENDENT],
 ['IO[30]', H_INDEPENDENT],
 ['IO[29]', H_INDEPENDENT],
-['IO[28]', H_DEPENDENT],
-['IO[27]', H_INDEPENDENT],
-['IO[26]', H_INDEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
 ['IO[25]', H_UNKNOWN],
 ['IO[24]', H_UNKNOWN],
 ['IO[23]', H_UNKNOWN],

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0254.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0254.py
@@ -1,0 +1,57 @@
+# gpio_config_def.py file for part VSD0254
+# io_config -- version 1.2.1
+voltage = 1.60
+analog = False
+
+H_NONE        = 0  
+H_DEPENDENT   = 1  
+H_INDEPENDENT = 2  
+H_SPECIAL     = 3  
+H_UNKNOWN     = 4  
+
+# voltage: 1.6
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_DEPENDENT],
+['IO[2]', H_INDEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_INDEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_INDEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.6
+# configuration failed in gpio[33], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_UNKNOWN],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0264.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0264.py
@@ -1,4 +1,4 @@
-# gpio_config_def.py file for part VSD0134
+# gpio_config_def.py file for part VSD0264
 # io_config -- version 1.2.1
 voltage = 1.60
 analog = False
@@ -10,16 +10,16 @@ H_SPECIAL     = 3
 H_UNKNOWN     = 4  
 
 # voltage: 1.6
-# configuration failed in gpio[8], anything after is invalid
+# configuration failed in gpio[6], anything after is invalid
 gpio_l = [
 ['IO[0]', H_NONE],
 ['IO[1]', H_DEPENDENT],
 ['IO[2]', H_DEPENDENT],
 ['IO[3]', H_DEPENDENT],
-['IO[4]', H_DEPENDENT],
+['IO[4]', H_INDEPENDENT],
 ['IO[5]', H_INDEPENDENT],
-['IO[6]', H_INDEPENDENT],
-['IO[7]', H_INDEPENDENT],
+['IO[6]', H_UNKNOWN],
+['IO[7]', H_UNKNOWN],
 ['IO[8]', H_UNKNOWN],
 ['IO[9]', H_UNKNOWN],
 ['IO[10]', H_UNKNOWN],
@@ -33,25 +33,25 @@ gpio_l = [
 ['IO[18]', H_UNKNOWN],
 ]
 # voltage: 1.6
-# configuration failed in gpio[25], anything before is invalid
+# IO configuration chain was successful
 gpio_h = [
 ['IO[37]', H_NONE],
-['IO[36]', H_DEPENDENT],
-['IO[35]', H_DEPENDENT],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
 ['IO[34]', H_DEPENDENT],
 ['IO[33]', H_INDEPENDENT],
-['IO[32]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
 ['IO[31]', H_INDEPENDENT],
 ['IO[30]', H_INDEPENDENT],
 ['IO[29]', H_INDEPENDENT],
-['IO[28]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
 ['IO[27]', H_INDEPENDENT],
 ['IO[26]', H_INDEPENDENT],
-['IO[25]', H_UNKNOWN],
-['IO[24]', H_UNKNOWN],
-['IO[23]', H_UNKNOWN],
-['IO[22]', H_UNKNOWN],
-['IO[21]', H_UNKNOWN],
-['IO[20]', H_UNKNOWN],
-['IO[19]', H_UNKNOWN],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
 ]

--- a/firmware/_includes/gpio_def/gpio_config_def_VSD0277.py
+++ b/firmware/_includes/gpio_def/gpio_config_def_VSD0277.py
@@ -1,0 +1,57 @@
+# gpio_config_def.py file for part VSD0277
+# io_config -- version 1.2.1
+voltage = 1.60
+analog = False
+
+H_NONE        = 0  
+H_DEPENDENT   = 1  
+H_INDEPENDENT = 2  
+H_SPECIAL     = 3  
+H_UNKNOWN     = 4  
+
+# voltage: 1.6
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_INDEPENDENT],
+['IO[5]', H_INDEPENDENT],
+['IO[6]', H_INDEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_INDEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_INDEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.6
+# configuration failed in gpio[21], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]


### PR DESCRIPTION
Uploading def files for 12 boards (8 passed 4 failed) spread across Batches 1,2,3. Adding missing def file for VSD0128 and modified VSD0134.

VSD0033 --> flash error (Project ID = ffffffff) . But Config passed with good pin count. Please refer file in commit
VSD0108 --> internal shorting affected supply of config board ( might be a board issue need to look into it )
VSD0106 --> Winbond sram not found
VSD0257 --> failed to receive ready signal from firmware.

@yathAg @kunalg123 